### PR TITLE
Fix path resolution in fetch_from_plan

### DIFF
--- a/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap.py
@@ -342,7 +342,7 @@ def make_distribution_archive(cabal_path):
     return archivename
 
 def fetch_from_plan(plan : FetchPlan, output_dir : Path):
-  output_dir.resolve()
+  output_dir = output_dir.resolve()
   output_dir.mkdir(parents=True, exist_ok=True)
 
   for path in plan:


### PR DESCRIPTION
## Summary
- ensure fetch_from_plan resolves output path before using it

## Testing
- `python3 -m py_compile bootstrap/bootstrap.py`
- `python3 -m py_compile doc/conf.py doc/cabaldomain.py`


------
https://chatgpt.com/codex/tasks/task_e_683fd81c69c483249d3a843e357e8f63